### PR TITLE
CI: Add local bootstrap and use editorial validation in CI

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,7 @@
 Please review [EIP-1](https://eips.ethereum.org/1/) for proposal guidelines.
 
+For the local multi-repo workflow, run `./scripts/dev-setup` from the repo
+root and use the canonical `build-eips` guide at
+<https://github.com/eips-wg/preprocessor#local-workspace-workflow>.
+
 <!-- RATIONALE FOR THIS FILE: IT IS DISPLAYED WHEN YOU CREATE AN ISSUE OR MAKE A PR -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: EIPs Build (Check)
         uses: ./.github/actions/build-eips
         with:
-          args: check --format github
+          args: editorial build --against-upstream --format github
 
   markdownlint:
     if: github.event.pull_request.base.repo.owner.login == 'ethereum' || github.event.pull_request.base.repo.owner.login == 'eips-wg'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,10 +20,7 @@ jobs:
       - name: EIPs Build (Build)
         uses: ./.github/actions/build-eips
         with:
-          # Disable eipw lints because there will never be any changed files
-          # between this checkout and `master` because, well, we just checked
-          # out `master`.
-          args: build --no-lint
+          args: build
 
       - name: Upload Artifact
         id: artifact

--- a/README.md
+++ b/README.md
@@ -58,8 +58,20 @@ automatically merged:
 
 ### Building Locally
 
-It is possible to run the above checks and preview how proposals will render
-using [`build-eips`]. See its documentation for more details.
+The easiest local workspace setup path in this repo is:
+
+```bash
+./scripts/dev-setup
+just serve
+```
+
+`./scripts/dev-setup` locates or installs `build-eips` and `just`, runs
+`workspace init`, refreshes the generated `justfile`, and prints the next
+useful commands.
+
+For the canonical multi-repo workflow, manual `build-eips` commands, and the
+generated `just` task surface, see the `build-eips` guide in
+[`eips-wg/preprocessor`](https://github.com/eips-wg/preprocessor#local-workspace-workflow).
 
 ## Preferred Citation Format
 

--- a/scripts/dev-setup
+++ b/scripts/dev-setup
@@ -1,0 +1,239 @@
+#!/bin/sh
+
+set -eu
+
+say() {
+    printf '%s\n' "$*"
+}
+
+die() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+pick_writable_home_path_dir() {
+    old_ifs=$IFS
+    IFS=:
+    for dir in $PATH; do
+        [ -n "$dir" ] || continue
+        [ -d "$dir" ] || continue
+        [ -w "$dir" ] || continue
+        case "$dir" in
+            "$HOME"|"$HOME"/*)
+                printf '%s\n' "$dir"
+                IFS=$old_ifs
+                return 0
+                ;;
+        esac
+    done
+    IFS=$old_ifs
+    return 1
+}
+
+pick_writable_path_dir() {
+    old_ifs=$IFS
+    IFS=:
+    for dir in $PATH; do
+        [ -n "$dir" ] || continue
+        [ -d "$dir" ] || continue
+        [ -w "$dir" ] || continue
+        printf '%s\n' "$dir"
+        IFS=$old_ifs
+        return 0
+    done
+    IFS=$old_ifs
+    return 1
+}
+
+pick_install_dir() {
+    if [ -n "${HOME:-}" ]; then
+        if dir=$(pick_writable_home_path_dir); then
+            printf '%s\n' "$dir"
+            return 0
+        fi
+
+        dir=$HOME/.local/bin
+        mkdir -p "$dir"
+        if [ -w "$dir" ]; then
+            printf '%s\n' "$dir"
+            return 0
+        fi
+    fi
+
+    pick_writable_path_dir
+}
+
+download() {
+    url=$1
+    destination=$2
+
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$url" -o "$destination"
+        return 0
+    fi
+
+    if command -v wget >/dev/null 2>&1; then
+        wget -qO "$destination" "$url"
+        return 0
+    fi
+
+    die "need curl or wget to download release binaries"
+}
+
+ensure_install_dir() {
+    [ -n "${INSTALL_DIR:-}" ] && return 0
+
+    INSTALL_DIR=$(pick_install_dir) || die "could not find a writable install directory"
+    case ":$PATH:" in
+        *:"$INSTALL_DIR":*)
+            ;;
+        *)
+            PATH=$INSTALL_DIR:$PATH
+            PATH_NOTE=$INSTALL_DIR
+            ;;
+    esac
+}
+
+cleanup_tmpdir() {
+    if [ -n "${TMPDIR_TO_CLEAN:-}" ]; then
+        rm -rf "$TMPDIR_TO_CLEAN"
+        TMPDIR_TO_CLEAN=
+    fi
+}
+
+install_build_eips() {
+    case "$(uname -s)" in
+        Linux)
+            archive_name=build-eips-ubuntu.tar.xz
+            ;;
+        Darwin)
+            archive_name=build-eips-macos.tar.xz
+            ;;
+        *)
+            die "unsupported operating system for automatic build-eips installation"
+            ;;
+    esac
+
+    command -v tar >/dev/null 2>&1 || die "need tar to unpack the build-eips release archive"
+    ensure_install_dir
+
+    tmpdir=$(mktemp -d)
+    TMPDIR_TO_CLEAN=$tmpdir
+    trap cleanup_tmpdir EXIT INT TERM
+
+    archive_path=$tmpdir/$archive_name
+    release_url=https://github.com/eips-wg/preprocessor/releases/latest/download/$archive_name
+
+    say "Installing build-eips from $release_url"
+    download "$release_url" "$archive_path"
+    tar -xf "$archive_path" -C "$tmpdir"
+    [ -f "$tmpdir/build-eips" ] || die "release archive did not contain build-eips"
+
+    cp "$tmpdir/build-eips" "$INSTALL_DIR/build-eips"
+    chmod +x "$INSTALL_DIR/build-eips"
+
+    BUILD_EIPS=$INSTALL_DIR/build-eips
+    cleanup_tmpdir
+}
+
+just_target() {
+    case "$(uname -s)" in
+        Linux)
+            case "$(uname -m)" in
+                x86_64|amd64)
+                    printf '%s\n' x86_64-unknown-linux-musl
+                    ;;
+                aarch64|arm64)
+                    printf '%s\n' aarch64-unknown-linux-musl
+                    ;;
+                *)
+                    die "unsupported Linux architecture for automatic just installation"
+                    ;;
+            esac
+            ;;
+        Darwin)
+            case "$(uname -m)" in
+                x86_64|amd64)
+                    printf '%s\n' x86_64-apple-darwin
+                    ;;
+                aarch64|arm64)
+                    printf '%s\n' aarch64-apple-darwin
+                    ;;
+                *)
+                    die "unsupported macOS architecture for automatic just installation"
+                    ;;
+            esac
+            ;;
+        *)
+            die "unsupported operating system for automatic just installation"
+            ;;
+    esac
+}
+
+install_just() {
+    command -v tar >/dev/null 2>&1 || die "need tar to unpack the just release archive"
+    ensure_install_dir
+
+    tmpdir=$(mktemp -d)
+    TMPDIR_TO_CLEAN=$tmpdir
+    trap cleanup_tmpdir EXIT INT TERM
+
+    target=$(just_target)
+    metadata_path=$tmpdir/just-release.json
+    archive_path=$tmpdir/just.tar.gz
+
+    download https://api.github.com/repos/casey/just/releases/latest "$metadata_path"
+    release_url=$(
+        tr ',' '\n' < "$metadata_path" |
+            sed -n "s#.*\"browser_download_url\"[[:space:]]*:[[:space:]]*\"\\([^\"]*/just-[^\"]*-$target\\.tar\\.gz\\)\".*#\\1#p"
+    )
+    [ -n "$release_url" ] || die "could not determine the latest just release download URL"
+
+    say "Installing just from $release_url"
+    download "$release_url" "$archive_path"
+    tar -xf "$archive_path" -C "$tmpdir"
+    [ -f "$tmpdir/just" ] || die "just release archive did not contain the just binary"
+
+    cp "$tmpdir/just" "$INSTALL_DIR/just"
+    chmod +x "$INSTALL_DIR/just"
+    cleanup_tmpdir
+}
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+WORKSPACE_ROOT=$(CDPATH= cd -- "$REPO_ROOT/.." && pwd)
+INSTALL_DIR=
+PATH_NOTE=
+TMPDIR_TO_CLEAN=
+
+if command -v build-eips >/dev/null 2>&1; then
+    BUILD_EIPS=$(command -v build-eips)
+    say "Using existing build-eips at $BUILD_EIPS"
+else
+    install_build_eips
+fi
+
+if command -v just >/dev/null 2>&1; then
+    say "Using existing just at $(command -v just)"
+else
+    install_just
+fi
+
+say "Bootstrapping workspace at $WORKSPACE_ROOT"
+"$BUILD_EIPS" workspace init "$WORKSPACE_ROOT"
+"$BUILD_EIPS" workspace refresh
+
+say "Running workspace doctor"
+if ! "$BUILD_EIPS" workspace doctor; then
+    say "Workspace doctor reported issues above. Fix them before relying on the local daily workflow."
+fi
+
+say ""
+say "Next commands:"
+say "  cd $REPO_ROOT"
+if [ -n "$PATH_NOTE" ]; then
+    say "  export PATH=\"$PATH_NOTE:\$PATH\""
+fi
+say "  just serve"
+say "  just check"
+say "  build-eips workspace doctor"


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is part of the coordinated multi-repo local build system series tracked in [preprocessor#8](https://github.com/eips-wg/preprocessor/issues/8). It is intended to land in coordination with [preprocessor#9](https://github.com/eips-wg/preprocessor/pull/9), [ERCs#10](https://github.com/eips-wg/ERCs/pull/10), and [template#1](https://github.com/eips-wg/template/pull/1). This PR depends on [preprocessor#9](https://github.com/eips-wg/preprocessor/pull/9) being merged and released first. Until the released `build-eips` binary includes the new editorial command surface, CI for this PR is expected to fail.

## Description

This PR adds the `EIPs`-side wiring for the local multi-repo build system.

In this repo, that means adding the checked-in local bootstrap entrypoint, updating repo-facing local workflow guidance, and aligning CI with the explicit `build-eips` editorial command surface introduced in [preprocessor#9](https://github.com/eips-wg/preprocessor/pull/9).

## Changes

- add `scripts/dev-setup` as the checked-in local workspace bootstrap helper
- update `README.md` and contributor guidance to point at the canonical local workspace guide
- switch CI to explicit editorial validation through `build-eips editorial`
- keep publish on the site build path

## Validation

Local verification for the `EIPs`-side workflow included:

- clean runtime checks and builds
- dirty runtime checks, builds, and serve behavior
- parity profile runtime checks
- explicit editorial linting
- editorial `--working-tree` selection and clean skip behavior

Final CI-shaped verification used a `build-eips` binary built from [preprocessor#9](https://github.com/eips-wg/preprocessor/pull/9).

From the rewritten `EIPs` branch, I ran:

- `build-eips --staging editorial build --against-upstream --format github`
- `build-eips --staging build`

The editorial selector resolved no changed proposal files relative to upstream, and the full staging site build completed successfully.
