### PR TITLE
CI: [V2:20] Add Repo Manifest

### DIFF
--- a/Build.toml
+++ b/Build.toml
@@ -1,0 +1,13 @@
+name = "EIPs"
+
+[locations.EIPs]
+repository = "https://github.com/eips-wg/EIPs.git"
+base-url = "https://eips-wg.github.io/EIPs/"
+
+[locations.ERCs]
+repository = "https://github.com/eips-wg/ERCs.git"
+base-url = "https://eips-wg.github.io/ERCs/"
+
+[theme]
+repository = "https://github.com/eips-wg/theme.git"
+commit = "0ddac35da36d311a8401c6cfb79c9991f78b647d"


### PR DESCRIPTION
> Part of [V2: Multi-repo local build system](https://github.com/eips-wg/preprocessor/issues/15).

## Description
Adds tracked `Build.toml` manifest so it can declare its own identity, related proposal repos, canonical base URLs, and theme pin.
